### PR TITLE
Update: `@herokwon/ui-common@0.1.0` 

### DIFF
--- a/.changeset/cold-readers-dress.md
+++ b/.changeset/cold-readers-dress.md
@@ -1,0 +1,11 @@
+---
+'@herokwon/ui-common': minor
+---
+
+- [x] **`ui-common`** 패키지 생성 및 초기 환경 설정
+- [x] **`Box`** 컴포넌트 구현 및 테스트 코드 추가
+- [x] **`Container`** 컴포넌트 구현 및 테스트 코드 추가
+- [x] **`Flex`** 컴포넌트 구현 및 테스트 코드 추가
+- [x] **`Grid`** 컴포넌트 구현 및 테스트 코드 추가
+- [x] **`Icon`** 컴포넌트 구현 및 테스트 코드 추가
+- [x] _Element_ / _Global_ / _Polymorphic_ 카테고리별 타입 구현

--- a/.changeset/gorgeous-brooms-talk.md
+++ b/.changeset/gorgeous-brooms-talk.md
@@ -1,0 +1,5 @@
+---
+'@herokwon/ui-config': patch
+---
+
+- [x] 타입 참조 & 타입명 변경 (_RestrictedOmit_ → **_OmitStrict_**)

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
   "singleQuote": true,
   "arrowParens": "avoid",
-  "importOrder": ["(.css)$", "^[../]", "^[./]"],
+  "importOrder": ["(.css)$", "types$", "^[../]", "^[./]"],
   "importOrderSeparation": true,
   "importOrderSortSpecifiers": true,
   "plugins": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -3467,7 +3467,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
       "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4046,6 +4045,10 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@herokwon/ui-common": {
+      "resolved": "packages/ui/common",
+      "link": true
+    },
     "node_modules/@herokwon/ui-config": {
       "resolved": "packages/ui/config",
       "link": true
@@ -4123,7 +4126,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4146,7 +4148,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4169,7 +4170,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4186,7 +4186,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4203,7 +4202,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4220,7 +4218,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4237,7 +4234,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4254,7 +4250,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4271,7 +4266,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4288,7 +4282,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4305,7 +4298,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4328,7 +4320,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4351,7 +4342,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4374,7 +4364,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4397,7 +4386,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4420,7 +4408,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4443,7 +4430,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -4463,7 +4449,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -4483,7 +4468,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -15383,7 +15367,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
       "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15454,7 +15437,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
       "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.25.0"
       },
@@ -16094,8 +16076,7 @@
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
       "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "4.3.0",
@@ -18837,9 +18818,36 @@
         "typescript": "^5.7.2"
       }
     },
+    "packages/ui/common": {
+      "name": "@herokwon/ui-common",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "next": "^15",
+        "react": "^19",
+        "react-dom": "^19"
+      },
+      "devDependencies": {
+        "@repo/tailwind-config": "*",
+        "@repo/typescript-config": "*",
+        "@types/eslint": "^9",
+        "@types/node": "^22",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "eslint": "^9",
+        "postcss": "^8",
+        "tailwindcss": "^3.4.17",
+        "typescript": "^5.7.2"
+      },
+      "peerDependencies": {
+        "next": "^15",
+        "react": "^19",
+        "react-dom": "^19"
+      }
+    },
     "packages/ui/config": {
       "name": "@herokwon/ui-config",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@repo/tailwind-config": "*",
@@ -18848,6 +18856,36 @@
         "eslint": "^9",
         "tailwindcss": "^3.4.16",
         "typescript": "^5.7.2"
+      }
+    },
+    "packages/ui/node_modules/@types/node": {
+      "version": "22.10.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
+      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
+    },
+    "packages/ui/node_modules/@types/react": {
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.2.tgz",
+      "integrity": "sha512-USU8ZI/xyKJwFTpjSVIrSeHBVAGagkHQKPNbxeWwql/vDmnTIBgx+TJnhFnj1NXgz8XfprU0egV2dROLGpsBEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "packages/ui/node_modules/@types/react-dom": {
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.2.tgz",
+      "integrity": "sha512-c1s+7TKFaDRRxr1TxccIX2u7sfCnc3RxkVyBIUA2lCpyqCF+QoAwQ/CBg7bsMdVwP120HEH143VQezKtef5nCg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.0.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15444,6 +15444,15 @@
         "react": "^19.0.0"
       }
     },
+    "node_modules/react-icons": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.4.0.tgz",
+      "integrity": "sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -18825,7 +18834,8 @@
       "dependencies": {
         "next": "^15",
         "react": "^19",
-        "react-dom": "^19"
+        "react-dom": "^19",
+        "react-icons": "^5.4.0"
       },
       "devDependencies": {
         "@repo/tailwind-config": "*",

--- a/packages/tailwind-config/tailwind.config.ts
+++ b/packages/tailwind-config/tailwind.config.ts
@@ -1,12 +1,9 @@
 import type { Config } from 'tailwindcss';
 
+import type { OmitStrict } from '../ui/common/src';
 import { tailwindExtendedTheme, tailwindPlugin } from '../ui/config/src';
 
-type RestrictedOmit<T, K extends keyof T> = {
-  [key in keyof T as key extends K ? never : key]: T[key];
-};
-
-const config: RestrictedOmit<Config, 'content'> = {
+const config: OmitStrict<Config, 'content'> = {
   darkMode: 'class',
   theme: {
     extend: tailwindExtendedTheme,

--- a/packages/ui/common/package.json
+++ b/packages/ui/common/package.json
@@ -21,12 +21,14 @@
   "dependencies": {
     "next": "^15",
     "react": "^19",
-    "react-dom": "^19"
+    "react-dom": "^19",
+    "react-icons": "^5.4.0"
   },
   "peerDependencies": {
     "next": "^15",
     "react": "^19",
-    "react-dom": "^19"
+    "react-dom": "^19",
+    "react-icons": "^5.4.0"
   },
   "devDependencies": {
     "@repo/tailwind-config": "*",

--- a/packages/ui/common/package.json
+++ b/packages/ui/common/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@herokwon/ui-common",
+  "version": "0.0.0",
+  "private": false,
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist/**/*"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "tsup",
+    "lint": "eslint . --max-warnings 0",
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "^15",
+    "react": "^19",
+    "react-dom": "^19"
+  },
+  "peerDependencies": {
+    "next": "^15",
+    "react": "^19",
+    "react-dom": "^19"
+  },
+  "devDependencies": {
+    "@repo/tailwind-config": "*",
+    "@repo/typescript-config": "*",
+    "@types/eslint": "^9",
+    "@types/node": "^22",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "eslint": "^9",
+    "postcss": "^8",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5.7.2"
+  },
+  "author": {
+    "name": "HeroKwon",
+    "email": "contact@herokwon.dev",
+    "url": "https://github.com/herokwon"
+  },
+  "bugs": {
+    "email": "contact@herokwon.dev",
+    "url": "https://github.com/herokwon/herokwon-ui/issues"
+  },
+  "contributors": [
+    {
+      "name": "HeroKwon",
+      "email": "contact@herokwon.dev",
+      "url": "https://github.com/herokwon"
+    }
+  ],
+  "keywords": [
+    "nextjs",
+    "tailwindcss",
+    "storybook",
+    "design-system"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/herokwon/herokwon-ui.git"
+  },
+  "description": "This is a common-package for simple design system by HeroKwon.",
+  "license": "MIT"
+}

--- a/packages/ui/common/postcss.config.mjs
+++ b/packages/ui/common/postcss.config.mjs
@@ -1,0 +1,8 @@
+import postcssConfig from '@repo/tailwind-config/postcss';
+
+/** @type {import('postcss-load-config').Config} */
+const config = {
+  ...postcssConfig,
+};
+
+export default config;

--- a/packages/ui/common/src/Box.tsx
+++ b/packages/ui/common/src/Box.tsx
@@ -1,0 +1,13 @@
+import type { PolymorphicPropsWithoutRef } from './types';
+
+type BoxProps<T extends React.ElementType> = PolymorphicPropsWithoutRef<T>;
+
+export default function Box<T extends React.ElementType = 'div'>({
+  as,
+  children,
+  ...props
+}: BoxProps<T>) {
+  const Element = as || 'div';
+
+  return <Element {...props}>{children}</Element>;
+}

--- a/packages/ui/common/src/Container.tsx
+++ b/packages/ui/common/src/Container.tsx
@@ -1,0 +1,69 @@
+import type {
+  ElementSize,
+  ElementSpacing,
+  OmitStrict,
+  PolymorphicPropsWithoutRef,
+} from './types';
+
+import Box from './Box';
+
+type ContainerElementType = 'div' | 'section';
+type ContainerProps<T extends ContainerElementType> =
+  PolymorphicPropsWithoutRef<
+    T,
+    {
+      fixed?: boolean;
+      maxWidth?: ElementSize;
+      padding?: ElementSpacing;
+    }
+  >;
+
+export default function Container<T extends ContainerElementType = 'div'>({
+  as,
+  children,
+  fixed = false,
+  maxWidth,
+  padding = 0,
+  ...props
+}: ContainerProps<T>) {
+  const element = as || 'div';
+  const elemProps = props as OmitStrict<
+    React.ComponentPropsWithoutRef<typeof element>,
+    'children'
+  >;
+
+  return (
+    <Box
+      {...elemProps}
+      as={element}
+      className={`${
+        fixed
+          ? `xs:is-[.container]:max-w-[512px] container xl:!max-w-screen-xl ${
+              maxWidth === 'xs'
+                ? 'xs:!max-w-screen-xs'
+                : maxWidth === 'sm'
+                  ? 'sm:!max-w-screen-sm'
+                  : maxWidth === 'md'
+                    ? 'md:!max-w-screen-md'
+                    : maxWidth === 'lg'
+                      ? 'lg:!max-w-screen-lg'
+                      : 'xl:!max-w-screen-xl'
+            }`
+          : maxWidth === 'xs'
+            ? 'max-w-screen-xs'
+            : maxWidth === 'sm'
+              ? 'max-w-screen-sm'
+              : maxWidth === 'md'
+                ? 'max-w-screen-md'
+                : maxWidth === 'lg'
+                  ? 'max-w-screen-lg'
+                  : 'max-w-screen-xl'
+      } ${elemProps.className ?? ''}`}
+      style={{
+        padding: `${padding * 0.25}rem`,
+      }}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/packages/ui/common/src/Flex.tsx
+++ b/packages/ui/common/src/Flex.tsx
@@ -1,0 +1,90 @@
+import type { Property } from 'csstype';
+
+import type {
+  ElementSpacing,
+  PolymorphicPropsWithoutRef,
+  PropertyWithoutGlobals,
+  RestrictedOmit,
+} from './types';
+
+import Box from './Box';
+
+type FlexProps<T extends React.ElementType> = PolymorphicPropsWithoutRef<
+  T,
+  {
+    flexDirection?: PropertyWithoutGlobals<Property.FlexDirection>;
+    flexWrap?: PropertyWithoutGlobals<Property.FlexWrap>;
+    gap?: ElementSpacing;
+  }
+>;
+type FlexItemProps<T extends React.ElementType> = PolymorphicPropsWithoutRef<
+  T,
+  {
+    flexBasis?: PropertyWithoutGlobals<Property.FlexBasis>;
+    flexGrow?: PropertyWithoutGlobals<Property.FlexGrow>;
+    flexShrink?: PropertyWithoutGlobals<Property.FlexShrink>;
+  }
+>;
+
+export default function Flex<T extends React.ElementType = 'div'>({
+  as,
+  children,
+  flexDirection = 'row',
+  flexWrap = 'nowrap',
+  gap = 0,
+  ...props
+}: FlexProps<T>) {
+  const element = as || 'div';
+  const elemProps = props as RestrictedOmit<
+    React.ComponentPropsWithoutRef<typeof element>,
+    'children'
+  >;
+
+  return (
+    <Box
+      {...elemProps}
+      as={element as React.ElementType}
+      className={`flex ${elemProps.className ?? ''}`}
+      style={{
+        ...elemProps.style,
+        flexDirection,
+        flexWrap,
+        gap: `${gap * 0.25}rem`,
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+const FlexItem = <T extends React.ElementType = 'div'>({
+  as,
+  children,
+  flexBasis = 'auto',
+  flexGrow = 0,
+  flexShrink = 1,
+  ...props
+}: FlexItemProps<T>) => {
+  const element = as || 'div';
+  const elemProps = props as RestrictedOmit<
+    React.ComponentPropsWithoutRef<typeof element>,
+    'children'
+  >;
+
+  return (
+    <Box
+      {...elemProps}
+      as={element as React.ElementType}
+      style={{
+        ...elemProps.style,
+        flexBasis,
+        flexGrow,
+        flexShrink,
+      }}
+    >
+      {children}
+    </Box>
+  );
+};
+
+Flex.Item = FlexItem;

--- a/packages/ui/common/src/Flex.tsx
+++ b/packages/ui/common/src/Flex.tsx
@@ -2,9 +2,9 @@ import type { Property } from 'csstype';
 
 import type {
   ElementSpacing,
+  OmitStrict,
   PolymorphicPropsWithoutRef,
   PropertyWithoutGlobals,
-  RestrictedOmit,
 } from './types';
 
 import Box from './Box';
@@ -35,7 +35,7 @@ export default function Flex<T extends React.ElementType = 'div'>({
   ...props
 }: FlexProps<T>) {
   const element = as || 'div';
-  const elemProps = props as RestrictedOmit<
+  const elemProps = props as OmitStrict<
     React.ComponentPropsWithoutRef<typeof element>,
     'children'
   >;
@@ -66,7 +66,7 @@ const FlexItem = <T extends React.ElementType = 'div'>({
   ...props
 }: FlexItemProps<T>) => {
   const element = as || 'div';
-  const elemProps = props as RestrictedOmit<
+  const elemProps = props as OmitStrict<
     React.ComponentPropsWithoutRef<typeof element>,
     'children'
   >;

--- a/packages/ui/common/src/Flex.tsx
+++ b/packages/ui/common/src/Flex.tsx
@@ -43,7 +43,7 @@ export default function Flex<T extends React.ElementType = 'div'>({
   return (
     <Box
       {...elemProps}
-      as={element as React.ElementType}
+      as={element}
       className={`flex ${elemProps.className ?? ''}`}
       style={{
         ...elemProps.style,
@@ -74,7 +74,7 @@ const FlexItem = <T extends React.ElementType = 'div'>({
   return (
     <Box
       {...elemProps}
-      as={element as React.ElementType}
+      as={element}
       style={{
         ...elemProps.style,
         flexBasis,

--- a/packages/ui/common/src/Grid.tsx
+++ b/packages/ui/common/src/Grid.tsx
@@ -94,8 +94,9 @@ export default function Grid<T extends React.ElementType = 'div'>({
       as={element}
       className={`grid ${elemProps.className ?? ''}`}
       style={{
-        rowGap,
-        columnGap,
+        ...elemProps.style,
+        rowGap: `${rowGap * 0.25}rem`,
+        columnGap: `${columnGap * 0.25}rem`,
         gridAutoRows: auto.rows,
         gridAutoColumns: auto.cols,
         gridAutoFlow: auto.flow,
@@ -139,6 +140,7 @@ const GridItem = <T extends React.ElementType = 'div'>({
       {...elemProps}
       as={element}
       style={{
+        ...elemProps.style,
         order,
         gridRowStart: row.start,
         gridRowEnd: row.end,

--- a/packages/ui/common/src/Grid.tsx
+++ b/packages/ui/common/src/Grid.tsx
@@ -1,0 +1,156 @@
+import type { Property } from 'csstype';
+
+import type {
+  ElementSpacing,
+  OmitStrict,
+  PolymorphicPropsWithoutRef,
+  PropertyWithoutGlobals,
+} from './types';
+
+import Box from './Box';
+
+type GridProps<T extends React.ElementType> = PolymorphicPropsWithoutRef<
+  T,
+  {
+    gap?:
+      | ElementSpacing
+      | {
+          row?: ElementSpacing;
+          col?: ElementSpacing;
+        };
+    auto?: {
+      rows?: PropertyWithoutGlobals<Property.GridAutoRows>;
+      cols?: PropertyWithoutGlobals<Property.GridAutoColumns>;
+      flow?:
+        | PropertyWithoutGlobals<Property.GridAutoFlow>
+        | 'row dense'
+        | 'column dense';
+    };
+    template?: {
+      rows?: PropertyWithoutGlobals<Property.GridTemplateRows>;
+      cols?: PropertyWithoutGlobals<Property.GridTemplateColumns>;
+    };
+    justify?: {
+      items?: PropertyWithoutGlobals<Property.JustifyItems>;
+      content?: PropertyWithoutGlobals<Property.JustifyContent>;
+    };
+    align?: {
+      items?: PropertyWithoutGlobals<Property.AlignItems>;
+      content?: PropertyWithoutGlobals<Property.AlignContent>;
+    };
+  }
+>;
+type GridItemProps<T extends React.ElementType> = PolymorphicPropsWithoutRef<
+  T,
+  {
+    order?: number;
+    row?: {
+      start?: number | `span ${number}` | 'auto';
+      end?: number | `span ${number}` | 'auto';
+    };
+    column?: {
+      start?: number | `span ${number}` | 'auto';
+      end?: number | `span ${number}` | 'auto';
+    };
+    justifySelf?: PropertyWithoutGlobals<Property.JustifySelf>;
+    alignSelf?: PropertyWithoutGlobals<Property.AlignSelf>;
+  }
+>;
+
+export default function Grid<T extends React.ElementType = 'div'>({
+  as,
+  children,
+  gap = 0,
+  auto = {
+    rows: 'auto',
+    cols: 'auto',
+    flow: 'row',
+  },
+  template = {
+    rows: 'none',
+    cols: 'none',
+  },
+  justify = {
+    items: 'legacy',
+    content: 'normal',
+  },
+  align = {
+    items: 'normal',
+    content: 'normal',
+  },
+  ...props
+}: GridProps<T>) {
+  const element = as || 'div';
+  const elemProps = props as OmitStrict<
+    React.ComponentPropsWithoutRef<typeof element>,
+    'children'
+  >;
+  const rowGap = typeof gap === 'number' ? gap : (gap.row ?? 0);
+  const columnGap = typeof gap === 'number' ? gap : (gap.col ?? 0);
+
+  return (
+    <Box
+      {...elemProps}
+      as={element}
+      className={`grid ${elemProps.className ?? ''}`}
+      style={{
+        rowGap,
+        columnGap,
+        gridAutoRows: auto.rows,
+        gridAutoColumns: auto.cols,
+        gridAutoFlow: auto.flow,
+        gridTemplateColumns: template.cols,
+        gridTemplateRows: template.rows,
+        justifyItems: justify.items,
+        justifyContent: justify.content,
+        alignItems: align.items,
+        alignContent: align.content,
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+const GridItem = <T extends React.ElementType = 'div'>({
+  as,
+  children,
+  order = 0,
+  row = {
+    start: 'auto',
+    end: 'auto',
+  },
+  column = {
+    start: 'auto',
+    end: 'auto',
+  },
+  justifySelf = 'auto',
+  alignSelf = 'auto',
+  ...props
+}: GridItemProps<T>) => {
+  const element = as || 'div';
+  const elemProps = props as OmitStrict<
+    React.ComponentPropsWithoutRef<typeof element>,
+    'children'
+  >;
+
+  return (
+    <Box
+      {...elemProps}
+      as={element}
+      style={{
+        order,
+        gridRowStart: row.start,
+        gridRowEnd: row.end,
+        gridColumnStart: column.start,
+        gridColumnEnd: column.end,
+        justifySelf,
+        alignSelf,
+      }}
+    >
+      {children}
+    </Box>
+  );
+};
+
+Grid.Item = GridItem;

--- a/packages/ui/common/src/Grid.tsx
+++ b/packages/ui/common/src/Grid.tsx
@@ -12,12 +12,10 @@ import Box from './Box';
 type GridProps<T extends React.ElementType> = PolymorphicPropsWithoutRef<
   T,
   {
-    gap?:
-      | ElementSpacing
-      | {
-          row?: ElementSpacing;
-          col?: ElementSpacing;
-        };
+    gap?: {
+      row?: ElementSpacing;
+      col?: ElementSpacing;
+    };
     auto?: {
       rows?: PropertyWithoutGlobals<Property.GridAutoRows>;
       cols?: PropertyWithoutGlobals<Property.GridAutoColumns>;
@@ -60,24 +58,11 @@ type GridItemProps<T extends React.ElementType> = PolymorphicPropsWithoutRef<
 export default function Grid<T extends React.ElementType = 'div'>({
   as,
   children,
-  gap = 0,
-  auto = {
-    rows: 'auto',
-    cols: 'auto',
-    flow: 'row',
-  },
-  template = {
-    rows: 'none',
-    cols: 'none',
-  },
-  justify = {
-    items: 'legacy',
-    content: 'normal',
-  },
-  align = {
-    items: 'normal',
-    content: 'normal',
-  },
+  gap,
+  auto,
+  template,
+  justify,
+  align,
   ...props
 }: GridProps<T>) {
   const element = as || 'div';
@@ -85,8 +70,6 @@ export default function Grid<T extends React.ElementType = 'div'>({
     React.ComponentPropsWithoutRef<typeof element>,
     'children'
   >;
-  const rowGap = typeof gap === 'number' ? gap : (gap.row ?? 0);
-  const columnGap = typeof gap === 'number' ? gap : (gap.col ?? 0);
 
   return (
     <Box
@@ -95,17 +78,17 @@ export default function Grid<T extends React.ElementType = 'div'>({
       className={`grid ${elemProps.className ?? ''}`}
       style={{
         ...elemProps.style,
-        rowGap: `${rowGap * 0.25}rem`,
-        columnGap: `${columnGap * 0.25}rem`,
-        gridAutoRows: auto.rows,
-        gridAutoColumns: auto.cols,
-        gridAutoFlow: auto.flow,
-        gridTemplateColumns: template.cols,
-        gridTemplateRows: template.rows,
-        justifyItems: justify.items,
-        justifyContent: justify.content,
-        alignItems: align.items,
-        alignContent: align.content,
+        rowGap: `${(gap?.row ?? 0) * 0.25}rem`,
+        columnGap: `${(gap?.col ?? 0) * 0.25}rem`,
+        gridAutoRows: auto?.rows ?? 'auto',
+        gridAutoColumns: auto?.cols ?? 'auto',
+        gridAutoFlow: auto?.flow ?? 'row',
+        gridTemplateColumns: template?.cols ?? 'none',
+        gridTemplateRows: template?.rows ?? 'none',
+        justifyItems: justify?.items ?? 'legacy',
+        justifyContent: justify?.content ?? 'normal',
+        alignItems: align?.items ?? 'normal',
+        alignContent: align?.content ?? 'normal',
       }}
     >
       {children}
@@ -117,14 +100,8 @@ const GridItem = <T extends React.ElementType = 'div'>({
   as,
   children,
   order = 0,
-  row = {
-    start: 'auto',
-    end: 'auto',
-  },
-  column = {
-    start: 'auto',
-    end: 'auto',
-  },
+  row,
+  column,
   justifySelf = 'auto',
   alignSelf = 'auto',
   ...props
@@ -142,10 +119,10 @@ const GridItem = <T extends React.ElementType = 'div'>({
       style={{
         ...elemProps.style,
         order,
-        gridRowStart: row.start,
-        gridRowEnd: row.end,
-        gridColumnStart: column.start,
-        gridColumnEnd: column.end,
+        gridRowStart: row?.start ?? 'auto',
+        gridRowEnd: row?.end ?? 'auto',
+        gridColumnStart: column?.start ?? 'auto',
+        gridColumnEnd: column?.end ?? 'auto',
         justifySelf,
         alignSelf,
       }}

--- a/packages/ui/common/src/Icon.tsx
+++ b/packages/ui/common/src/Icon.tsx
@@ -1,0 +1,28 @@
+import type { IconBaseProps, IconType } from 'react-icons';
+
+import type { ElementSize, OmitStrict } from './types';
+
+type IconProps = OmitStrict<IconBaseProps, 'type'> & {
+  type: IconType;
+  size?: ElementSize;
+};
+
+const ICON_SIZE: { [key in ElementSize]: number } = {
+  xs: 0.75,
+  sm: 0.875,
+  md: 1,
+  lg: 1.25,
+  xl: 1.5,
+};
+
+export default function Icon({ type, size = 'md', ...props }: IconProps) {
+  const IconElement = type;
+
+  return (
+    <IconElement
+      {...props}
+      size={`${ICON_SIZE[size]}rem`}
+      className={`aspect-square ${props.className ?? ''}`}
+    />
+  );
+}

--- a/packages/ui/common/src/__tests__/Box.test.tsx
+++ b/packages/ui/common/src/__tests__/Box.test.tsx
@@ -31,20 +31,9 @@ describe('Box', () => {
     );
     const box = screen.getByTestId('box');
 
+    expect(box).toHaveTextContent('props');
     expect(box).toBeInTheDocument();
     expect(box).toHaveClass('box');
     expect(box).toHaveTextContent('props');
-  });
-
-  it('should render children correctly', () => {
-    render(
-      <Box>
-        <span>child</span>
-      </Box>,
-    );
-    const child = screen.getByText('child');
-
-    expect(child).toBeInTheDocument();
-    expect(child.tagName).toBe('SPAN');
   });
 });

--- a/packages/ui/common/src/__tests__/Box.test.tsx
+++ b/packages/ui/common/src/__tests__/Box.test.tsx
@@ -9,6 +9,7 @@ describe('Box', () => {
 
     expect(box).toBeInTheDocument();
     expect(box.tagName).toBe('DIV');
+    expect(box).toHaveTextContent('default');
   });
 
   it('should render as a different element', () => {
@@ -21,6 +22,7 @@ describe('Box', () => {
 
     expect(box).toBeInTheDocument();
     expect(box.tagName).toBe('A');
+    expect(box).toHaveTextContent('anchor');
   });
 
   it('should pass props to the element correctly', () => {
@@ -31,9 +33,8 @@ describe('Box', () => {
     );
     const box = screen.getByTestId('box');
 
-    expect(box).toHaveTextContent('props');
     expect(box).toBeInTheDocument();
-    expect(box).toHaveClass('box');
     expect(box).toHaveTextContent('props');
+    expect(box).toHaveClass('box');
   });
 });

--- a/packages/ui/common/src/__tests__/Box.test.tsx
+++ b/packages/ui/common/src/__tests__/Box.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+
+import Box from '../Box';
+
+describe('Box', () => {
+  it('should render as a div by default', () => {
+    render(<Box>default</Box>);
+    const box = screen.getByText('default');
+
+    expect(box).toBeInTheDocument();
+    expect(box.tagName).toBe('DIV');
+  });
+
+  it('should render as a different element', () => {
+    render(
+      <Box as="a" href="/">
+        anchor
+      </Box>,
+    );
+    const box = screen.getByText('anchor');
+
+    expect(box).toBeInTheDocument();
+    expect(box.tagName).toBe('A');
+  });
+
+  it('should pass props to the element correctly', () => {
+    render(
+      <Box data-testid="box" className="box">
+        props
+      </Box>,
+    );
+    const box = screen.getByTestId('box');
+
+    expect(box).toBeInTheDocument();
+    expect(box).toHaveClass('box');
+    expect(box).toHaveTextContent('props');
+  });
+
+  it('should render children correctly', () => {
+    render(
+      <Box>
+        <span>child</span>
+      </Box>,
+    );
+    const child = screen.getByText('child');
+
+    expect(child).toBeInTheDocument();
+    expect(child.tagName).toBe('SPAN');
+  });
+});

--- a/packages/ui/common/src/__tests__/Container.test.tsx
+++ b/packages/ui/common/src/__tests__/Container.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+
+import { ELEMENT_SIZES } from '../types';
+
+import Container from '../Container';
+
+describe('Container', () => {
+  it('should render with default props', () => {
+    render(<Container>default</Container>);
+    const container = screen.getByText('default');
+
+    expect(container).toBeInTheDocument();
+    expect(container.tagName).toBe('DIV');
+  });
+
+  it('should render as a section element', () => {
+    render(<Container as="section">section</Container>);
+    const container = screen.getByText('section');
+
+    expect(container).toBeInTheDocument();
+    expect(container.tagName).toBe('SECTION');
+  });
+
+  for (const isFixed of [true, false]) {
+    for (const size of ELEMENT_SIZES) {
+      it('should pass props to the element correctly', () => {
+        render(
+          <Container
+            data-testid="container"
+            fixed={isFixed}
+            maxWidth={size}
+            padding={4}
+          >
+            props
+          </Container>,
+        );
+        const container = screen.getByTestId('container');
+
+        expect(container).toHaveTextContent('props');
+        if (!isFixed) expect(container).toHaveClass(`max-w-screen-${size}`);
+        else {
+          expect(container).toHaveClass('container');
+          expect(container).toHaveClass(`${size}:!max-w-screen-${size}`);
+        }
+      });
+    }
+  }
+});

--- a/packages/ui/common/src/__tests__/Container.test.tsx
+++ b/packages/ui/common/src/__tests__/Container.test.tsx
@@ -11,6 +11,7 @@ describe('Container', () => {
 
     expect(container).toBeInTheDocument();
     expect(container.tagName).toBe('DIV');
+    expect(container).toHaveTextContent('default');
   });
 
   it('should render as a section element', () => {
@@ -19,6 +20,7 @@ describe('Container', () => {
 
     expect(container).toBeInTheDocument();
     expect(container.tagName).toBe('SECTION');
+    expect(container).toHaveTextContent('section');
   });
 
   for (const isFixed of [true, false]) {
@@ -36,6 +38,7 @@ describe('Container', () => {
         );
         const container = screen.getByTestId('container');
 
+        expect(container).toBeInTheDocument();
         expect(container).toHaveTextContent('props');
         if (!isFixed) expect(container).toHaveClass(`max-w-screen-${size}`);
         else {

--- a/packages/ui/common/src/__tests__/Flex.test.tsx
+++ b/packages/ui/common/src/__tests__/Flex.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+
+import Flex from '../Flex';
+
+describe('Flex', () => {
+  it('should render with default props', () => {
+    render(<Flex>default</Flex>);
+    const flex = screen.getByText('default');
+
+    expect(flex).toBeInTheDocument();
+    expect(flex.tagName).toBe('DIV');
+    expect(flex).toHaveClass('flex');
+    expect(flex).toHaveStyle('flex-direction: row');
+    expect(flex).toHaveStyle('flex-wrap: nowrap');
+    expect(flex).toHaveStyle('gap: 0rem');
+  });
+
+  it('should render as a different element', () => {
+    render(<Flex as="section">section</Flex>);
+    const flex = screen.getByText('section');
+
+    expect(flex).toBeInTheDocument();
+    expect(flex.tagName).toBe('SECTION');
+  });
+
+  it('should pass props to the element correctly', () => {
+    render(
+      <Flex data-testid="flex" flexDirection="column" flexWrap="wrap" gap={4}>
+        props
+      </Flex>,
+    );
+    const flex = screen.getByTestId('flex');
+
+    expect(flex).toHaveStyle('flex-direction: column');
+    expect(flex).toHaveStyle('flex-wrap: wrap');
+    expect(flex).toHaveStyle('gap: 1rem');
+  });
+});
+
+describe('FlexItem', () => {
+  it('should render with default props', () => {
+    render(<Flex.Item>default</Flex.Item>);
+    const flexItem = screen.getByText('default');
+
+    expect(flexItem).toBeInTheDocument();
+    expect(flexItem.tagName).toBe('DIV');
+    expect(flexItem).toHaveStyle('flex-basis: auto');
+    expect(flexItem).toHaveStyle('flex-grow: 0');
+    expect(flexItem).toHaveStyle('flex-shrink: 1');
+  });
+
+  it('should render as a different element', () => {
+    render(<Flex.Item as="span">span</Flex.Item>);
+    const FlexItem = screen.getByText('span');
+
+    expect(FlexItem).toBeInTheDocument();
+    expect(FlexItem.tagName).toBe('SPAN');
+  });
+
+  it('should pass props to the element correctly', () => {
+    render(
+      <Flex.Item
+        data-testid="flex-item"
+        flexBasis="content"
+        flexGrow={1}
+        flexShrink={2}
+      >
+        props
+      </Flex.Item>,
+    );
+    const flexItem = screen.getByTestId('flex-item');
+
+    expect(flexItem).toHaveStyle('flex-basis: content');
+    expect(flexItem).toHaveStyle('flex-grow: 1');
+    expect(flexItem).toHaveStyle('flex-shrink: 2');
+  });
+});

--- a/packages/ui/common/src/__tests__/Flex.test.tsx
+++ b/packages/ui/common/src/__tests__/Flex.test.tsx
@@ -31,6 +31,7 @@ describe('Flex', () => {
     );
     const flex = screen.getByTestId('flex');
 
+    expect(flex).toHaveTextContent('props');
     expect(flex).toHaveStyle('flex-direction: column');
     expect(flex).toHaveStyle('flex-wrap: wrap');
     expect(flex).toHaveStyle('gap: 1rem');
@@ -70,6 +71,7 @@ describe('FlexItem', () => {
     );
     const flexItem = screen.getByTestId('flex-item');
 
+    expect(flexItem).toHaveTextContent('props');
     expect(flexItem).toHaveStyle('flex-basis: content');
     expect(flexItem).toHaveStyle('flex-grow: 1');
     expect(flexItem).toHaveStyle('flex-shrink: 2');

--- a/packages/ui/common/src/__tests__/Flex.test.tsx
+++ b/packages/ui/common/src/__tests__/Flex.test.tsx
@@ -9,10 +9,13 @@ describe('Flex', () => {
 
     expect(flex).toBeInTheDocument();
     expect(flex.tagName).toBe('DIV');
+    expect(flex).toHaveTextContent('default');
     expect(flex).toHaveClass('flex');
-    expect(flex).toHaveStyle('flex-direction: row');
-    expect(flex).toHaveStyle('flex-wrap: nowrap');
-    expect(flex).toHaveStyle('gap: 0rem');
+    expect(flex).toHaveStyle({
+      'flex-direction': 'row',
+      'flex-wrap': 'nowrap',
+      gap: '0rem',
+    });
   });
 
   it('should render as a different element', () => {
@@ -21,6 +24,7 @@ describe('Flex', () => {
 
     expect(flex).toBeInTheDocument();
     expect(flex.tagName).toBe('SECTION');
+    expect(flex).toHaveTextContent('section');
   });
 
   it('should pass props to the element correctly', () => {
@@ -31,10 +35,13 @@ describe('Flex', () => {
     );
     const flex = screen.getByTestId('flex');
 
+    expect(flex).toBeInTheDocument();
     expect(flex).toHaveTextContent('props');
-    expect(flex).toHaveStyle('flex-direction: column');
-    expect(flex).toHaveStyle('flex-wrap: wrap');
-    expect(flex).toHaveStyle('gap: 1rem');
+    expect(flex).toHaveStyle({
+      'flex-direction': 'column',
+      'flex-wrap': 'wrap',
+      gap: '1rem',
+    });
   });
 });
 
@@ -45,17 +52,21 @@ describe('FlexItem', () => {
 
     expect(flexItem).toBeInTheDocument();
     expect(flexItem.tagName).toBe('DIV');
-    expect(flexItem).toHaveStyle('flex-basis: auto');
-    expect(flexItem).toHaveStyle('flex-grow: 0');
-    expect(flexItem).toHaveStyle('flex-shrink: 1');
+    expect(flexItem).toHaveTextContent('default');
+    expect(flexItem).toHaveStyle({
+      'flex-basis': 'auto',
+      'flex-grow': '0',
+      'flex-shrink': '1',
+    });
   });
 
   it('should render as a different element', () => {
     render(<Flex.Item as="span">span</Flex.Item>);
-    const FlexItem = screen.getByText('span');
+    const flexItem = screen.getByText('span');
 
-    expect(FlexItem).toBeInTheDocument();
-    expect(FlexItem.tagName).toBe('SPAN');
+    expect(flexItem).toBeInTheDocument();
+    expect(flexItem.tagName).toBe('SPAN');
+    expect(flexItem).toHaveTextContent('span');
   });
 
   it('should pass props to the element correctly', () => {
@@ -71,9 +82,12 @@ describe('FlexItem', () => {
     );
     const flexItem = screen.getByTestId('flex-item');
 
+    expect(flexItem).toBeInTheDocument();
     expect(flexItem).toHaveTextContent('props');
-    expect(flexItem).toHaveStyle('flex-basis: content');
-    expect(flexItem).toHaveStyle('flex-grow: 1');
-    expect(flexItem).toHaveStyle('flex-shrink: 2');
+    expect(flexItem).toHaveStyle({
+      'flex-basis': 'content',
+      'flex-grow': '1',
+      'flex-shrink': '2',
+    });
   });
 });

--- a/packages/ui/common/src/__tests__/Grid.test.tsx
+++ b/packages/ui/common/src/__tests__/Grid.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+
+import Grid from '../Grid';
+
+describe('Grid', () => {
+  it('should render with default props', () => {
+    render(<Grid>default</Grid>);
+    const grid = screen.getByText('default');
+
+    expect(grid).toBeInTheDocument();
+    expect(grid.tagName).toBe('DIV');
+    expect(grid).toHaveClass('grid');
+  });
+
+  it('should render as a different element', () => {
+    render(<Grid as="section">section</Grid>);
+    const grid = screen.getByText('section');
+
+    expect(grid).toBeInTheDocument();
+    expect(grid.tagName).toBe('SECTION');
+  });
+
+  it('should pass props to the element correctly', () => {
+    render(
+      <Grid
+        data-testid="grid"
+        gap={{
+          row: 8,
+          col: 4,
+        }}
+      >
+        props
+      </Grid>,
+    );
+    const grid = screen.getByTestId('grid');
+
+    expect(grid).toHaveStyle('row-gap: 2rem');
+    expect(grid).toHaveStyle('column-gap: 1rem');
+  });
+});
+
+describe('GridItem', () => {
+  it('should render with default props', () => {
+    render(<Grid.Item>default</Grid.Item>);
+    const gridItem = screen.getByText('default');
+
+    expect(gridItem).toBeInTheDocument();
+    expect(gridItem.tagName).toBe('DIV');
+    expect(gridItem).toHaveStyle('order: 0');
+    expect(gridItem).toHaveStyle('grid-row-start: auto');
+    expect(gridItem).toHaveStyle('grid-row-end: auto');
+    expect(gridItem).toHaveStyle('grid-column-start: auto');
+    expect(gridItem).toHaveStyle('grid-column-end: auto');
+  });
+
+  it('should render as a different element', () => {
+    render(<Grid.Item as="span">span</Grid.Item>);
+    const gridItem = screen.getByText('span');
+
+    expect(gridItem).toBeInTheDocument();
+    expect(gridItem.tagName).toBe('SPAN');
+  });
+
+  it('should pass props to the element correctly', () => {
+    render(
+      <Grid.Item
+        data-testid="grid-item"
+        order={1}
+        justifySelf="center"
+        alignSelf="center"
+      >
+        props
+      </Grid.Item>,
+    );
+    const gridItem = screen.getByTestId('grid-item');
+
+    expect(gridItem).toHaveTextContent('props');
+    expect(gridItem).toHaveStyle('order: 1');
+    expect(gridItem).toHaveStyle('justify-self: center');
+    expect(gridItem).toHaveStyle('align-self: center');
+  });
+});

--- a/packages/ui/common/src/__tests__/Grid.test.tsx
+++ b/packages/ui/common/src/__tests__/Grid.test.tsx
@@ -9,6 +9,7 @@ describe('Grid', () => {
 
     expect(grid).toBeInTheDocument();
     expect(grid.tagName).toBe('DIV');
+    expect(grid).toHaveTextContent('default');
     expect(grid).toHaveClass('grid');
   });
 
@@ -18,6 +19,7 @@ describe('Grid', () => {
 
     expect(grid).toBeInTheDocument();
     expect(grid.tagName).toBe('SECTION');
+    expect(grid).toHaveTextContent('section');
   });
 
   it('should pass props to the element correctly', () => {
@@ -28,14 +30,34 @@ describe('Grid', () => {
           row: 8,
           col: 4,
         }}
+        auto={{
+          flow: 'row dense',
+        }}
+        template={{
+          rows: 'repeat(auto-fit, minmax(0, 200px))',
+        }}
+        justify={{
+          content: 'center',
+        }}
+        align={{
+          items: 'center',
+        }}
       >
         props
       </Grid>,
     );
     const grid = screen.getByTestId('grid');
 
-    expect(grid).toHaveStyle('row-gap: 2rem');
-    expect(grid).toHaveStyle('column-gap: 1rem');
+    expect(grid).toBeInTheDocument();
+    expect(grid).toHaveTextContent('props');
+    expect(grid).toHaveStyle({
+      'row-gap': '2rem',
+      'column-gap': '1rem',
+      'grid-auto-flow': 'row dense',
+      'grid-template-rows': 'repeat(auto-fit, minmax(0, 200px))',
+      'justify-content': 'center',
+      'align-items': 'center',
+    });
   });
 });
 
@@ -46,11 +68,14 @@ describe('GridItem', () => {
 
     expect(gridItem).toBeInTheDocument();
     expect(gridItem.tagName).toBe('DIV');
-    expect(gridItem).toHaveStyle('order: 0');
-    expect(gridItem).toHaveStyle('grid-row-start: auto');
-    expect(gridItem).toHaveStyle('grid-row-end: auto');
-    expect(gridItem).toHaveStyle('grid-column-start: auto');
-    expect(gridItem).toHaveStyle('grid-column-end: auto');
+    expect(gridItem).toHaveTextContent('default');
+    expect(gridItem).toHaveStyle({
+      order: '0',
+      'grid-row-start': 'auto',
+      'grid-row-end': 'auto',
+      'grid-column-start': 'auto',
+      'grid-column-end': 'auto',
+    });
   });
 
   it('should render as a different element', () => {
@@ -59,6 +84,7 @@ describe('GridItem', () => {
 
     expect(gridItem).toBeInTheDocument();
     expect(gridItem.tagName).toBe('SPAN');
+    expect(gridItem).toHaveTextContent('span');
   });
 
   it('should pass props to the element correctly', () => {
@@ -66,6 +92,14 @@ describe('GridItem', () => {
       <Grid.Item
         data-testid="grid-item"
         order={1}
+        row={{
+          start: 1,
+          end: 2,
+        }}
+        column={{
+          start: 2,
+          end: 'span 2',
+        }}
         justifySelf="center"
         alignSelf="center"
       >
@@ -74,9 +108,16 @@ describe('GridItem', () => {
     );
     const gridItem = screen.getByTestId('grid-item');
 
+    expect(gridItem).toBeInTheDocument();
     expect(gridItem).toHaveTextContent('props');
-    expect(gridItem).toHaveStyle('order: 1');
-    expect(gridItem).toHaveStyle('justify-self: center');
-    expect(gridItem).toHaveStyle('align-self: center');
+    expect(gridItem).toHaveStyle({
+      order: '1',
+      'grid-row-start': '1',
+      'grid-row-end': '2',
+      'grid-column-start': '2',
+      'grid-column-end': 'span 2',
+      'justify-self': 'center',
+      'align-self': 'center',
+    });
   });
 });

--- a/packages/ui/common/src/__tests__/Icon.test.tsx
+++ b/packages/ui/common/src/__tests__/Icon.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { FaCheck } from 'react-icons/fa6';
+
+import Icon from '../Icon';
+
+describe('Icon', () => {
+  it('should render with default props', () => {
+    render(<Icon data-testid="icon" type={FaCheck} />);
+    const icon = screen.getByTestId('icon');
+
+    expect(icon).toBeInTheDocument();
+    expect(icon.tagName).toBe('svg');
+  });
+
+  it('should pass props to the element correctly', () => {
+    render(<Icon data-testid="icon" type={FaCheck} size="xs" />);
+    const icon = screen.getByTestId('icon');
+
+    expect(icon).toHaveAttribute('width', '0.75rem');
+    expect(icon).toHaveAttribute('height', '0.75rem');
+  });
+});

--- a/packages/ui/common/src/index.css
+++ b/packages/ui/common/src/index.css
@@ -1,0 +1,3 @@
+@import 'tailwindcss/base';
+@import 'tailwindcss/components';
+@import 'tailwindcss/utilities';

--- a/packages/ui/common/src/index.ts
+++ b/packages/ui/common/src/index.ts
@@ -3,3 +3,5 @@ import './index.css';
 export * from './types';
 
 export { default as Box } from './Box';
+export { default as Flex } from './Flex';
+export { default as Grid } from './Grid';

--- a/packages/ui/common/src/index.ts
+++ b/packages/ui/common/src/index.ts
@@ -1,0 +1,3 @@
+import './index.css';
+
+export * from './types';

--- a/packages/ui/common/src/index.ts
+++ b/packages/ui/common/src/index.ts
@@ -1,3 +1,5 @@
 import './index.css';
 
 export * from './types';
+
+export { default as Box } from './Box';

--- a/packages/ui/common/src/index.ts
+++ b/packages/ui/common/src/index.ts
@@ -3,5 +3,7 @@ import './index.css';
 export * from './types';
 
 export { default as Box } from './Box';
+export { default as Container } from './Container';
 export { default as Flex } from './Flex';
 export { default as Grid } from './Grid';
+export { default as Icon } from './Icon';

--- a/packages/ui/common/src/types.ts
+++ b/packages/ui/common/src/types.ts
@@ -1,0 +1,42 @@
+const ELEMENT_SIZES = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+const ELEMENT_SPACINGS = [0, 2, 4, 6, 8, 10, 12, 16, 20] as const;
+const ELEMENT_STATUS = ['isDisabled', 'isSelected', 'isLoading'] as const;
+
+// Element
+export type ElementSize = (typeof ELEMENT_SIZES)[number];
+export type ElementBaseSize = Exclude<ElementSize, 'xs' | 'xl'>;
+export type ElementSpacing = (typeof ELEMENT_SPACINGS)[number];
+export type ElementStatus = {
+  [key in (typeof ELEMENT_STATUS)[number]]?: boolean;
+};
+
+// Global
+export type RestrictedOmit<T, K extends keyof T> = {
+  [key in keyof T as key extends K ? never : key]: T[key];
+};
+export type Children = NonNullable<React.ReactNode>;
+export type PropsWithChildren<Props extends object = {}> = {
+  children: Children;
+} & Omit<Props, 'children'>;
+export type PropsWithId<Props extends object = {}> = {
+  id: string;
+} & Omit<Props, 'id'>;
+
+// Polymorphic
+type AsProp<T extends React.ElementType> = {
+  as?: T;
+};
+export type PolymorphicRef<T extends React.ElementType> =
+  React.ComponentPropsWithRef<T>['ref'];
+export type PolymorphicPropsWithoutRef<
+  T extends React.ElementType,
+  Props extends object = {},
+> = AsProp<T> &
+  Props &
+  RestrictedOmit<React.ComponentPropsWithoutRef<T>, keyof (AsProp<T> & Props)>;
+export type PolymorphicPropsWithRef<
+  T extends React.ElementType,
+  Props extends object = {},
+> = {
+  ref?: PolymorphicRef<T>;
+} & PolymorphicPropsWithoutRef<T, Props>;

--- a/packages/ui/common/src/types.ts
+++ b/packages/ui/common/src/types.ts
@@ -1,3 +1,5 @@
+import type { Globals } from 'csstype';
+
 const ELEMENT_SIZES = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
 const ELEMENT_SPACINGS = [0, 2, 4, 6, 8, 10, 12, 16, 20] as const;
 const ELEMENT_STATUS = ['isDisabled', 'isSelected', 'isLoading'] as const;
@@ -21,6 +23,7 @@ export type PropsWithChildren<Props extends object = {}> = {
 export type PropsWithId<Props extends object = {}> = {
   id: string;
 } & Omit<Props, 'id'>;
+export type PropertyWithoutGlobals<P> = Exclude<P, Globals>;
 
 // Polymorphic
 type AsProp<T extends React.ElementType> = {

--- a/packages/ui/common/src/types.ts
+++ b/packages/ui/common/src/types.ts
@@ -1,6 +1,6 @@
 import type { Globals } from 'csstype';
 
-const ELEMENT_SIZES = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+export const ELEMENT_SIZES = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
 const ELEMENT_SPACINGS = [0, 2, 4, 6, 8, 10, 12, 16, 20] as const;
 const ELEMENT_STATUS = ['isDisabled', 'isSelected', 'isLoading'] as const;
 

--- a/packages/ui/common/src/types.ts
+++ b/packages/ui/common/src/types.ts
@@ -1,8 +1,12 @@
 import type { Globals } from 'csstype';
 
 export const ELEMENT_SIZES = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
-const ELEMENT_SPACINGS = [0, 2, 4, 6, 8, 10, 12, 16, 20] as const;
-const ELEMENT_STATUS = ['isDisabled', 'isSelected', 'isLoading'] as const;
+export const ELEMENT_SPACINGS = [0, 2, 4, 6, 8, 10, 12, 16, 20] as const;
+export const ELEMENT_STATUS = [
+  'isDisabled',
+  'isSelected',
+  'isLoading',
+] as const;
 
 // Element
 export type ElementSize = (typeof ELEMENT_SIZES)[number];

--- a/packages/ui/common/src/types.ts
+++ b/packages/ui/common/src/types.ts
@@ -13,7 +13,7 @@ export type ElementStatus = {
 };
 
 // Global
-export type RestrictedOmit<T, K extends keyof T> = {
+export type OmitStrict<T, K extends keyof T> = {
   [key in keyof T as key extends K ? never : key]: T[key];
 };
 export type Children = NonNullable<React.ReactNode>;
@@ -36,7 +36,7 @@ export type PolymorphicPropsWithoutRef<
   Props extends object = {},
 > = AsProp<T> &
   Props &
-  RestrictedOmit<React.ComponentPropsWithoutRef<T>, keyof (AsProp<T> & Props)>;
+  OmitStrict<React.ComponentPropsWithoutRef<T>, keyof (AsProp<T> & Props)>;
 export type PolymorphicPropsWithRef<
   T extends React.ElementType,
   Props extends object = {},

--- a/packages/ui/common/tailwind.config.ts
+++ b/packages/ui/common/tailwind.config.ts
@@ -1,0 +1,10 @@
+import tailwindConfig from '@repo/tailwind-config';
+
+import type { Config } from 'tailwindcss';
+
+const config: Pick<Config, 'content' | 'presets'> = {
+  content: ['src/**/*.{js,ts,jsx,tsx,mdx}'],
+  presets: [tailwindConfig],
+};
+
+export default config;

--- a/packages/ui/common/tsconfig.json
+++ b/packages/ui/common/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@repo/typescript-config/nextjs.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "outDir": "dist",
+    "types": ["@testing-library/jest-dom"]
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/ui/config/CHANGELOG.md
+++ b/packages/ui/config/CHANGELOG.md
@@ -4,5 +4,6 @@
 
 ### Minor Changes
 
-- 3a32587: - [x] TailwindCSS 커스텀 변수 (_xs_, _scrollbar_, _slider_, _progress_) 추가
+- 3a32587:
+  - [x] TailwindCSS 커스텀 변수 (_xs_, _scrollbar_, _slider_, _progress_) 추가
   - [x] TailwindCSS 커스텀 유틸리티 스타일 객체화 리팩토링 & 테스트 코드 추가

--- a/packages/ui/config/src/__tests__/plugin.test.ts
+++ b/packages/ui/config/src/__tests__/plugin.test.ts
@@ -4,9 +4,22 @@ import {
   hiddenScrollbar,
   scrollbarX,
   scrollbarY,
-} from '../plugins';
+} from '../plugins/utils';
 
 describe('tailwindPlugin', () => {
+  // it('should re-export all modules correctly', () => {
+  //   expect(plugins).toHaveProperty('baseButton');
+  //   expect(plugins).toHaveProperty('baseCode');
+  //   expect(plugins).toHaveProperty('baseHeading');
+  //   expect(plugins).toHaveProperty('baseInput');
+  //   expect(plugins).toHaveProperty('baseTable');
+  //   expect(plugins).toHaveProperty('customVariants');
+  //   expect(plugins).toHaveProperty('scrollbarX');
+  //   expect(plugins).toHaveProperty('scrollbarY');
+  //   expect(plugins).toHaveProperty('hiddenScrollbar');
+  //   expect(plugins).toHaveProperty('bgUnderline');
+  // });
+
   it('customVariants', () => {
     expect(customVariants).toStrictEqual({
       scrollbar: '&::-webkit-scrollbar',

--- a/packages/ui/config/src/__tests__/plugins/button.test.ts
+++ b/packages/ui/config/src/__tests__/plugins/button.test.ts
@@ -1,4 +1,4 @@
-import { baseButton } from '../../plugins';
+import { baseButton } from '../../plugins/button';
 
 describe('baseButton', () => {
   it('should have correct styles for disabled button elements', () => {

--- a/packages/ui/config/src/__tests__/plugins/code.test.ts
+++ b/packages/ui/config/src/__tests__/plugins/code.test.ts
@@ -1,4 +1,4 @@
-import { baseCode } from '../../plugins';
+import { baseCode } from '../../plugins/code';
 
 describe('baseCode', () => {
   it('should have correct styles for code and pre elements', () => {

--- a/packages/ui/config/src/__tests__/plugins/heading.test.ts
+++ b/packages/ui/config/src/__tests__/plugins/heading.test.ts
@@ -1,4 +1,4 @@
-import { baseHeading } from '../../plugins';
+import { baseHeading } from '../../plugins/heading';
 
 describe('baseHeading', () => {
   it('should have correct styles for h1', () => {

--- a/packages/ui/config/src/__tests__/plugins/input.test.ts
+++ b/packages/ui/config/src/__tests__/plugins/input.test.ts
@@ -1,4 +1,4 @@
-import { baseInput } from '../../plugins';
+import { baseInput } from '../../plugins/input';
 
 describe('baseInput', () => {
   it('should have correct styles for input elements', () => {

--- a/packages/ui/config/src/__tests__/plugins/table.test.ts
+++ b/packages/ui/config/src/__tests__/plugins/table.test.ts
@@ -1,4 +1,4 @@
-import { baseTable } from '../../plugins';
+import { baseTable } from '../../plugins/table';
 
 describe('baseTable', () => {
   it('should have correct styles for table', () => {

--- a/packages/ui/config/src/__tests__/theme.test.ts
+++ b/packages/ui/config/src/__tests__/theme.test.ts
@@ -1,12 +1,9 @@
 import tailwindExtendedTheme from '../theme';
-import {
-  extendedBgColors,
-  extendedColors,
-  extendedHeight,
-  extendedOpacity,
-  extendedTextColors,
-  extendedWidth,
-} from '../themes';
+import { extendedBgColors } from '../themes/background';
+import { extendedColors } from '../themes/color';
+import { extendedOpacity } from '../themes/effect';
+import { extendedHeight, extendedWidth } from '../themes/size';
+import { extendedTextColors } from '../themes/typography';
 
 describe('tailwindExtendedTheme', () => {
   it('should have entire properties', () => {

--- a/packages/ui/config/src/__tests__/themes/background.test.ts
+++ b/packages/ui/config/src/__tests__/themes/background.test.ts
@@ -1,4 +1,4 @@
-import { extendedBgColors } from '../../themes';
+import { extendedBgColors } from '../../themes/background';
 
 describe('extendedBgColors', () => {
   it('should have default background colors', () => {

--- a/packages/ui/config/src/__tests__/themes/color.test.ts
+++ b/packages/ui/config/src/__tests__/themes/color.test.ts
@@ -1,4 +1,4 @@
-import { extendedColors } from '../../themes';
+import { extendedColors } from '../../themes/color';
 
 describe('extendedColors', () => {
   it('should have brown colors', () => {

--- a/packages/ui/config/src/__tests__/themes/effect.test.ts
+++ b/packages/ui/config/src/__tests__/themes/effect.test.ts
@@ -1,4 +1,4 @@
-import { extendedOpacity } from '../../themes';
+import { extendedOpacity } from '../../themes/effect';
 
 describe('extendedOpacity', () => {
   it('should have bold opacity value', () => {

--- a/packages/ui/config/src/__tests__/themes/size.test.ts
+++ b/packages/ui/config/src/__tests__/themes/size.test.ts
@@ -1,4 +1,4 @@
-import { extendedHeight, extendedWidth } from '../../themes';
+import { extendedHeight, extendedWidth } from '../../themes/size';
 
 describe('extendedSizes', () => {
   it('should have size for 0px', () => {

--- a/packages/ui/config/src/__tests__/themes/typography.test.ts
+++ b/packages/ui/config/src/__tests__/themes/typography.test.ts
@@ -1,4 +1,4 @@
-import { extendedTextColors } from '../../themes';
+import { extendedTextColors } from '../../themes/typography';
 
 describe('extendedTextColors', () => {
   it('should have default text colors', () => {

--- a/packages/ui/config/src/plugin.ts
+++ b/packages/ui/config/src/plugin.ts
@@ -1,17 +1,17 @@
 import plugin from 'tailwindcss/plugin';
 
+import { baseButton } from './plugins/button';
+import { baseCode } from './plugins/code';
+import { baseHeading } from './plugins/heading';
+import { baseInput } from './plugins/input';
+import { baseTable } from './plugins/table';
 import {
-  baseButton,
-  baseCode,
-  baseHeading,
-  baseInput,
-  baseTable,
   bgUnderline,
   customVariants,
   hiddenScrollbar,
   scrollbarX,
   scrollbarY,
-} from './plugins';
+} from './plugins/utils';
 
 const tailwindPlugin = plugin(
   ({ addBase, addVariant, addUtilities, matchVariant, matchUtilities }) => {

--- a/packages/ui/config/src/plugin.ts
+++ b/packages/ui/config/src/plugin.ts
@@ -37,6 +37,9 @@ const tailwindPlugin = plugin(
     });
 
     addUtilities({
+      '.max-w-screen-xs': {
+        'max-width': '512px',
+      },
       '.scrollbar-x': scrollbarX,
       '.scrollbar-y': scrollbarY,
       '.hidden-scrollbar': hiddenScrollbar,

--- a/packages/ui/config/src/plugins/index.ts
+++ b/packages/ui/config/src/plugins/index.ts
@@ -1,6 +1,0 @@
-export * from './button';
-export * from './code';
-export * from './heading';
-export * from './input';
-export * from './table';
-export * from './utils';

--- a/packages/ui/config/src/theme.ts
+++ b/packages/ui/config/src/theme.ts
@@ -1,13 +1,10 @@
 import type { CustomThemeConfig } from 'tailwindcss/types/config';
 
-import {
-  extendedBgColors,
-  extendedColors,
-  extendedHeight,
-  extendedOpacity,
-  extendedTextColors,
-  extendedWidth,
-} from './themes';
+import { extendedBgColors } from './themes/background';
+import { extendedColors } from './themes/color';
+import { extendedOpacity } from './themes/effect';
+import { extendedHeight, extendedWidth } from './themes/size';
+import { extendedTextColors } from './themes/typography';
 
 const tailwindExtendedTheme: Partial<CustomThemeConfig> = {
   width: extendedWidth,

--- a/packages/ui/config/src/themes/index.ts
+++ b/packages/ui/config/src/themes/index.ts
@@ -1,5 +1,0 @@
-export * from './background';
-export * from './color';
-export * from './effect';
-export * from './size';
-export * from './typography';

--- a/packages/ui/eslint.config.mjs
+++ b/packages/ui/eslint.config.mjs
@@ -16,6 +16,9 @@ const __dirname = path.dirname(__filename);
 export default [
   ...eslintConfig,
   {
+    rules: {
+      '@typescript-eslint/no-empty-object-type': 'off',
+    },
     languageOptions: {
       parser: tsParser,
       ecmaVersion: 5,


### PR DESCRIPTION
## 작업 개요

> [**`@herokwon/ui-common`**](https://npmjs.com/package/@herokwon/ui-common/v/0.1.0) 업데이트

<br />

## 상세 내용

- [x] **ui-common**
  - **`Box`** 컴포넌트 구현 및 테스트 코드 추가
  - **`Container`** 컴포넌트 구현 및 테스트 코드 추가
  - **`Flex`** 컴포넌트 구현 및 테스트 코드 추가
  - **`Grid`** 컴포넌트 구현 및 테스트 코드 추가
  - **`Icon`** 컴포넌트 구현 및 테스트 코드 추가
  - _Element_ / _Global_ / _Polymorphic_ 카테고리별 타입 구현
- [x] **ui-config**
  - 타입 참조 & 타입명 변경 (_RestrictedOmit_ → **_OmitStrict_**)