### PR TITLE
Fix: Typo in `Release` workflow (feat. GitHub Actions)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
             github.rest.issues.createComment({
               issue_number: ${{steps.pr.outputs.result }},
               owner: context.repo.owner,
-              repo: content.repo.repo,
+              repo: context.repo.repo,
               body: ':rocket: storybook: ${{ steps.chromatic.outputs.storybookUrl }}'
             });
 


### PR DESCRIPTION
## 작업 개요

> GitHub Actions `Release` workflow 오타 수정

<br />

## 상세 내용

- [x] **`Release`** workflow
  - 오타 수정 (content ❌, context ✅)